### PR TITLE
Add La Huerta product purchase CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,13 @@
 
 1. Enter token in .env
 2. Run start.bat
+
+## La Huerta Product Purchase CLI
+
+A small command-line app that lets you add La Huerta products to a cart and see the total.
+
+Run with:
+
+```
+node la-huerta-app.js
+```

--- a/la-huerta-app.js
+++ b/la-huerta-app.js
@@ -1,0 +1,51 @@
+import input from "input";
+import products from "./la-huerta-products.js";
+
+const cart = [];
+
+const listProducts = () => {
+  console.log("Available La Huerta products:");
+  products.forEach((p) => {
+    console.log(`${p.id}. ${p.name} - $${p.price}`);
+  });
+};
+
+const addToCart = async () => {
+  while (true) {
+    const idStr = await input.text(
+      "Enter product ID to add or press ENTER to checkout:"
+    );
+    if (!idStr) break;
+    const product = products.find((p) => p.id === Number(idStr));
+    if (!product) {
+      console.log("Invalid product ID");
+      continue;
+    }
+    const qtyStr = await input.text("Quantity:");
+    const qty = Number(qtyStr);
+    if (isNaN(qty) || qty <= 0) {
+      console.log("Invalid quantity");
+      continue;
+    }
+    cart.push({ ...product, quantity: qty });
+  }
+};
+
+const checkout = () => {
+  console.log("\nPurchase summary:");
+  let total = 0;
+  cart.forEach((item) => {
+    const subtotal = item.price * item.quantity;
+    total += subtotal;
+    console.log(`${item.name} x${item.quantity} - $${subtotal}`);
+  });
+  console.log(`Total: $${total}`);
+};
+
+const main = async () => {
+  listProducts();
+  await addToCart();
+  checkout();
+};
+
+main();

--- a/la-huerta-products.js
+++ b/la-huerta-products.js
@@ -1,0 +1,7 @@
+const products = [
+  { id: 1, name: "Broccoli Florets 500g", price: 35 },
+  { id: 2, name: "Mixed Vegetables 1kg", price: 50 },
+  { id: 3, name: "Spinach 400g", price: 40 }
+];
+
+export default products;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "main": "app.js",
   "type": "module",
   "license": "MIT",
+  "scripts": {
+    "purchase": "node la-huerta-app.js"
+  },
   "dependencies": {
     "axios": "^0.23.0",
     "dotenv": "^10.0.0",


### PR DESCRIPTION
## Summary
- add a simple CLI app to purchase sample La Huerta products
- expose purchase script and document usage

## Testing
- `npm test` (fails: missing script)
- `npm run purchase` with sample input

------
https://chatgpt.com/codex/tasks/task_e_68b86f00bf70832fa6f3d378608c36da